### PR TITLE
fix: remove non-working constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The action also supports the following optional inputs:
 * `memory`: Required memory, will be converted to *Gi and Gi must not be supplied. Defaults to `1`(Gi).
 
 > [!TIP]
-> The latest possible `cpu` and `memory` combinations can be found at [Workload profiles in Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/workload-profiles-overview). The Action will error out if one chooses an invalid combination of `cpu` and `memory`.
+> If you run into an error, the available combinations can be seen in the error log.
 
 ## Outputs
 The action provides the following outputs:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The action also supports the following optional inputs:
 * `memory`: Required memory, will be converted to *Gi and Gi must not be supplied. Defaults to `1`(Gi).
 
 > [!TIP]
-> If you run into an error, the available combinations can be seen in the error log.
+> If you run into an error, the available `cpu`/`memory` combinations can be seen in the error log.
 
 ## Outputs
 The action provides the following outputs:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ The action also supports the following optional inputs:
 * `max_replicas`: Maximum number of replicas for the container app. Default: `1`
 * `location`: Location of the Azure Container Apps environment. Default: `switzerlandnorth`
 * `cache_tag`: Tag to use for caching the docker build. Default: `dockercache`
-* `cpu`: CPUs to allocate for the container app cores from 0.25 - 2.0, e.g. 0.5. Defaults to `0.5`.
-* `memory`: Required memory from 0.5 - 4.0, will be converted to *Gi and Gi must not be supplied. Defaults to `1`(Gi).
+* `cpu`: CPUs to allocate for the container app cores. Defaults to `0.5`.
+* `memory`: Required memory, will be converted to *Gi and Gi must not be supplied. Defaults to `1`(Gi).
+
+> [!TIP]
+> The latest possible `cpu` and `memory` combinations can be found at [Workload profiles in Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/workload-profiles-overview). The Action will error out if one chooses an invalid combination of `cpu` and `memory`.
 
 ## Outputs
 The action provides the following outputs:

--- a/action.yaml
+++ b/action.yaml
@@ -147,35 +147,6 @@ runs:
         fi
         echo "All requirements met."
 
-    - name: Check inputs
-      shell: bash
-      run: |
-        CPU=${{ inputs.module }}
-        MEM=${{ inputs.memory }}
-        
-        is_valid_number() {
-            number=$1
-            lower_limit=$2
-            upper_limit=$3
-            re='^[0-9]+([.][0-9]+)?$'  # Regular expression for a valid number
-            if echo "$number" | grep -Eq "$re"; then
-                if [ "$(echo "$number >= $lower_limit" | bc -l)" = 1 ] && [ "$(echo "$number <= $upper_limit" | bc -l)" = 1 ]; then
-                    return 0
-                fi
-            fi
-            return 1
-        }
-        
-        if ! is_valid_number "$CPU" 0.25 2; then
-            echo "CPU setting is invalid, must be between 0.25 and 2!"
-        fi
-
-        if ! is_valid_number "$CPU" 0.5 4; then
-            echo "Memory setting is invalid, must be between 0.5 and 4!"
-        fi
-
-        echo "All inputs valid."
-
     - name: Set up Azure CLI
       uses: azure/login@v2
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -91,11 +91,11 @@ inputs:
     default: 'dockercache'
     type: string
   cpu:
-    description: 'CPUs to allocate for the container app cores from 0.25 - 2.0, e.g. 0.5.'
+    description: 'CPUs to allocate for the container app cores.'
     required: false
     default: '0.5'
   memory:
-    description: 'Required memory from 0.5 - 4.0, will be converted to *Gi and Gi must not be supplied.'
+    description: 'Required memory, will be converted to *Gi and Gi must not be supplied.'
     required: false
     default: '1'
 outputs:


### PR DESCRIPTION
The Azure RM API does actually validate the workload combinations pairs itself. Since there are limited combos, we might as well just not manually validate them and let the Azure RM report the issues.

`v3` tag will be moved as no functionality changes and we never agreed on a tagging system.

Refs: UN-6995